### PR TITLE
Add regular meeting notes from 18.01.2024

### DIFF
--- a/Meetings/RegularMeetings/2024-01-18.md
+++ b/Meetings/RegularMeetings/2024-01-18.md
@@ -1,0 +1,128 @@
+# WebAgents CG: Regular Meeting (Jan. 18, 2024)
+
+## Agenda
+   * Introduction
+       * Introduction of new participants (if any)
+       * General CG updates
+   * Review of Task Forces
+       * Task Force Proposal: Manageable Affordances
+   * Open discussion
+
+## Participants
+   * Andrei Ciortea
+   * Antoine Zimmermann
+   * Arthur Casals
+   * Pierre-Antoine Champin
+   * Rem Collier
+   * SImon Mayer
+   * Danai Vachtsevanou
+   * Gabriel Lopes 
+   * Ege Korkan
+   * Patrick Hochstenbach
+   * Wout Slabbinck
+   * Samuele Burattini
+   * Eoin Hobson-O'Neill
+   * Nicoletta Fornara
+   * Sabrina Kirrane
+   * Fabien Gandon
+   * Julian Padget
+
+**Scribe**: Antoine Zimmermann
+
+## Meeting Notes
+
+### Introduction of new participants:
+
+Iwona (Yvonna) Sokalska: PhD student from Toronto Metropolitan University, developing topic of the role of centralized consensus in Web3. Startup founder for content licensing . Interested how to automate web agents to interact on our content licensing service. Has background in natural language processing, graph datasets, transaction engines.
+
+Eoin O'Neill: PhD student at uni college Dublin. Multiagent microservices. Use web principles in microservice architectures. Allow agents to use microservices in a Web fashion.
+
+Patrick Hochstenbach: Ghent univ. PhD student, creating protocols for services in decentralised network for scholarly communication. My research provides standards that can be used as decentralized alternative for massive centralization of scholatly pulishing Automated web agents that navigate this network are part of my research. 
+
+Gabriel Lopes: work on KGs, Master on it. PhD applied to IoT. Interest in MAS.
+
+Arthur Casals: currently working on MAS (architecture/planning/coordination) and belief change/revision.  
+
+### Updates on the Community Group:
+
+Charter is online on the landing page of the CG: [https://www.w3.org/community/webagents/](https://www.w3.org/community/webagents/)
+
+Most things in W3C groups happen on Github. For the WebAgents CG see: [https://github.com/w3c-cg/webagents](https://github.com/w3c-cg/webagents)
+
+Remember to link your GitHub account to you W3C account to contribute! (You can do that on your W3C account page)
+
+There is 1 folder for meetings, a folder for task forces
+
+There is also a wiki ([https://github.com/w3c-cg/webagents/wiki)](https://github.com/w3c-cg/webagents/wiki)). There are sections on MAS, SemWeb, Web arch. We want to gather content on these topics to provide an efficient introduction to these areas.
+
+Also on the wiki, a page on regular meetings with general info and agenda for individual meetings.
+
+There are 2 times slots for regular meetings (Thursday 8:00 UCT and Monday 15:00 UCT)
+
+You can propose new topics for meetings using a Google form: [https://docs.google.com/forms/d/e/1FAIpQLScCx0H-cQO-MtCai-iR\_aGfiCabjr\_paYHrPlCAnJxBSa3ohg/viewform](https://docs.google.com/forms/d/e/1FAIpQLScCx0H-cQO-MtCai-iR\_aGfiCabjr\_paYHrPlCAnJxBSa3ohg/viewform)
+
+**Anyone** can propose a topic for discussion at any time.
+
+Minutes from previous meetings in the Github repo, folder "Meetings"
+
+There is the transcription of the recording of Zoom meeting.
+
+
+### Manageable affordance Task Force
+
+Propose TF description at: [https://github.com/w3c-cg/webagents/pull/19](https://github.com/w3c-cg/webagents/pull/19)
+
+Ege and Andrei lead this TF
+
+About working on thing descriptions where actions are long lasting. Especially if there is a physical process, e.g., moving from one place to another.
+
+This work is relevant to the charter of the WoT WG. We cannot propose recommendations as a community group but we can provide input to them.
+
+Simon: at what level this group is working (engineering, abstract, syntactic, ...)?
+
+Ege: it is low level in the sense that we need to know how it will look like in a Thing Description
+
+Andrei: the title is very broad. We want to explore this with a WebAgents perspective
+
+ ... part of the TF is to define what's the interest of the CG on the topic
+
+ ... it is uneasy to programme web app with asynchronous behaviours
+
+Ege: there are proposols of implementations for WoT TDs [https://github.com/w3c/wot-thing-description/tree/main/proposals](https://github.com/w3c/wot-thing-description/tree/main/proposals)
+
+Simon: to Sabrina and Nicoletta, does it have a connection with regulation (wrt what you want to explore)?
+
+[some missed sentences]
+
+Ege: ... proposing mechanisms
+
+Patrick: long lasting can be very long (e.g. weeks/months) in scholalary communication use-cases. We cannot use a REST approaches that would require endless pulling of services. In our project we are using message based approach a profile of Linked Data Notifications. We could use Hydra but its not enough. Also the communication patterns are not static, the web agent should be able to cope with a dynamic communication style.  In  our approach reasoning and rules that describe the dynamic communication patterns. Sources: [https://www.eventnotifications.net](https://www.eventnotifications.net)     [https://journal.code4lib.org/articles/17823](https://journal.code4lib.org/articles/17823) 
+
+Andrei: we are looking at actions with a time dimension. We could look at the commitments by agents when they start an action.
+
+Simon: we do not necessarily need very long actions to encounter those issues.
+
+Ege: there can be events running for some time. E.g. an alarm off until fire is extinguished
+
+Rem: (to Sabrina) you can use the Google form to provide your ideas about what to do with a TF on policies and norms
+
+Sabrina: I'd like to see the interest of other people in such TF (policies \& norms)
+
+Interest in policies and norms according to the chat:
+   * Sabrina Kirrane
+   * Antoine Zimmermann
+   * Arthur Casals
+   * Wout Slabbinck
+   * Nicoletta Fornara
+   * Julian Padget
+   * Stephen Cranefield
+
+Antoine: We are going to provide a description of the use case TF. You can already provide UC descriptions in the wiki. I've put an example.
+
+Ivona: please provide pointers so that we are more up to date in next meetings
+
+Simon: these meetings are good places to counter misconception (e,g., "WoT is all about robots!")
+
+Gabriel: how the temporal aspect of things or agents are represented? That some properties are changing over time.
+
+Antoine: "temporal aspect" can related to many things. Recording time points (like in logs) which can be represented as a simple dateime literal. If you need relative times of e.g. events, you can use Allen's agebra. For reasoning with time, there are modal temporal logics, or annotated temporal logics. Related to time, there's the notion of processes, for which there are various representation. There isn't a unique, well established way of representing these in MAS or SemWeb.

--- a/Meetings/RegularMeetings/README.md
+++ b/Meetings/RegularMeetings/README.md
@@ -1,0 +1,15 @@
+# WebAgents CG Meetings
+
+The WebAgents Community Group (CG) is meeting every 2 weeks on **Mondays (4-5 PM CET)** and **Thursdays (9-10 AM CET)** ([timezone conversions](https://www.timeanddate.com/worldclock/converter.html)). All CG events are published in the [group's calendar](https://www.w3.org/groups/cg/webagents/calendar/).
+
+The typical agenda of a regular meeting includes:
+* Introduction [15 min]
+  * Introduction of new participants (if any)
+  * Review minutes from the previous meeting
+  * General CG updates
+* Review of Task Forces [15 min]
+  * Proposals of new task forces (if any)
+  * Updates from ongoing task forces
+* Open discussion [30 min]
+
+If you wish to propose content for a regular meeting (a talk, demo, discussion topic, task force, etc.), you can do so by [filling out this form](https://forms.gle/nDutVGCAmpmapPLi6).


### PR DESCRIPTION
These are the meeting notes from the regular meeting of WebAgents CG on 18.01.2024.