### PR TITLE
Add regular meeting notes from 29.01.2024

### DIFF
--- a/Meetings/RegularMeetings/2024-01-29.md
+++ b/Meetings/RegularMeetings/2024-01-29.md
@@ -1,0 +1,106 @@
+# WebAgents CG: Regular Meeting (Jan. 29, 2024)
+
+## Agenda
+   * Introduction
+       * Introduction of new participants (if any)
+       * Review minutes from the previous meeting
+       * General CG updates
+   * Review of Task Forces
+       * Task Force Proposal: Use Cases
+       * Manageable Affordances Task Force
+   * Open discussion
+
+## Participants
+   * Jean-Paul Calbimonte
+   * Samuele Burattini
+   * Andrei Ciortea
+   * Nicoletta Fornara
+   * Jérémy Lemée
+   * Simon Mayer
+   * Gustavo Nardin
+   * Dave Raggett
+   * Alexandru Soricci
+   * Danai Vachtsevanou
+   * Kalyani Yogeswaranathan
+   * Antoine Zimmermann
+   * Rem Collier
+   * Ege Korkan
+**Scribe**: *Danai Vachtsevanou*
+
+## Meeting Notes
+
+### Introduction of new participants
+
+*Luis Gustavo Nardin*: Assoc prof at École des mines de Saint-Étienne. Interested in regulating multi-agent systems on the Web    
+
+### General CG Updates
+
+**Proposing content for upcoming meetings:** You can fill out [this form]([https://docs.google.com/forms/d/e/1FAIpQLScCx0H-cQO-MtCai-iR\_aGfiCabjr\_paYHrPlCAnJxBSa3ohg/viewform) to propose content for a regular meeting of the W3C WebAgents CG (a talk, demo, discussion topic, task force, etc.). Anyone is welcomed to join the meetings — and to propose content.
+
+**Next meeting:**
+* 15 Feb 2024, 9:00-10:00 CET
+* An export link or ics file is available at the bottom of the Web Agents CG Calendar page: [https://www.w3.org/groups/cg/webagents/calendar/](https://www.w3.org/groups/cg/webagents/calendar/)
+
+### Review of Task Forces
+
+**Use case Task Force (UC TF): **
+* Relevant PR: [https://github.com/w3c-cg/webagents/pull/21](https://github.com/w3c-cg/webagents/pull/21)
+* Available templates: [https://github.com/w3c-cg/webagents/blob/main/.github/manageable-affordances/issue\_template.md](https://github.com/w3c-cg/webagents/blob/main/.github/manageable-affordances/issue\_template.md), [https://github.com/w3c/wot-usecases](https://github.com/w3c/wot-usecases)
+* Any form of use case proposal with some informal paragraphs will suffice for now, and will then be re-formulated according to a selected template.
+* Goals (also see the PR): 
+  * Identify requirements based on the use cases for agents on the Web and Multi-Agent Systems;
+  * Categorize use cases to identify the relations (similarities and differences) between them;
+  * Discuss the challenges of applying approaches aligned to Web Agents for implementing the use case.
+  * New use case proposals can currently be added in the Wiki page ([https://github.com/w3c-cg/webagents/wiki/Use-cases-for-Autonomous-Web-Agents](https://github.com/w3c-cg/webagents/wiki/Use-cases-for-Autonomous-Web-Agents))
+
+Andrei: This Task Force (TF) could be used as a middle ground for different TFs, and for communication purposes to external collaborators.
+
+Ege: Agrees that a curated list of use cases could be used for communication purposes    
+
+**Manageable Affordances Task Force (MA TF)**
+
+* Feedback from last weeks has been addressed in the TF proposal: [https://github.com/w3c-cg/webagents/tree/main/TaskForces/ManageableAffordance](https://github.com/w3c-cg/webagents/tree/main/TaskForces/ManageableAffordance)
+* The available template can now be used for submitting proposals, and opening related PRs:   [https://github.com/w3c-cg/webagents/blob/main/.github/manageable-affordances/issue\_template.md](https://github.com/w3c-cg/webagents/blob/main/.github/manageable-affordances/issue\_template.md)
+* Rem: The type of use cases of the UC TF may differ from the ones of the MA TF initially, and they may inform each other.
+* Andrei: The use cases in MA TF may be more focuses than the ones initially discussed in UC TF.
+* Andrei: The goal for the next meeting is to gather a few proposal by then, so that we can discuss the proposals and can already identify known mechanisms that could be used for applying the proposals.
+* Andrei: Initially, the TF can focus on long-running actions. It is concrete, specific, and already of interest to the WoT CG.
+* Ege: Proposed use cases will be discussed in the next meeting (they can be as verbose as you like). 
+
+**Policies and Norms TF**
+
+   * An initial description is still required, for example, following a similar TF description (e.g., see [the decription of the MA TF]([https://github.com/w3c-cg/webagents/tree/main/TaskForces/ManageableAffordance))
+
+**Proposal submission guidelines:**
+
+* Use one of the available templates ([https://github.com/w3c-cg/webagents/blob/main/.github/manageable-affordances/issue\_template.md](https://github.com/w3c-cg/webagents/blob/main/.github/manageable-affordances/issue\_template.md), [https://github.com/w3c/wot-usecases)](https://github.com/w3c/wot-usecases))
+
+* Submit your proposal:
+  * For the UC TF: Submit the proposal as part of a GitHub issue, or as part of the Wiki and open a PR.
+  * For the MA TF: Submit the proposal as part of a GitHub issue, or as part of 
+
+Nicoletta: [to submit a use case already discussed in a past Dagstuhl Seminar (12111)]
+
+Dave: How many use cases are expected in the MA TF?
+
+Andrei: There are at least three foreseen use case based on previous discussions (e.g., Siemens, Univ. of St.Gallen, Ghent University).
+
+Jérémy: What is the difference in the scope of the use cases developed in the different TFs?
+
+Andrei: The use cases of the UC TF shall have a broader scope, and will motivate the use of agents and multi-agent systems on the Web, for example, in different domains. The use cases of the MA TF will be more focused, initially on long-running actions. For example, a use case from the UC TF can be examined across separate smaller use cases of the MA TF.
+
+Antoine: There will be required coordination between the UC TF and the remaining TFs. The UC TF should make sure that there is convergence with the other TFs, and there are no duplicate UCs accross TFs.
+
+Arthur: Is it possible to submit a TF proposal/draft/etc via GitHub and discuss it before the next meeting?
+
+Andrei: A first proposal draft could already be submitted for discussion through [this form](https://docs.google.com/forms/d/e/1FAIpQLScCx0H-cQO-MtCai-iR\_aGfiCabjr\_paYHrPlCAnJxBSa3ohg/viewform).
+
+Antoine: Discussions can also start through the mailing list.
+
+Ege: Example of a very long running action when creating an organization in PyPi: [https://github.com/w3c-cg/webagents/assets/20195407/f1d42900-9207-4590-969d-ee81e10a476f](https://github.com/w3c-cg/webagents/assets/20195407/f1d42900-9207-4590-969d-ee81e10a476f) (probably a human needs to confirm it at some point...)
+
+
+
+
+
+


### PR DESCRIPTION
These are the meeting notes from the regular meeting of WebAgents CG on 29.01.2024.