### PR TITLE
Add regular meeting notes from 17.06.2024

### DIFF
--- a/Meetings/RegularMeetings/2024-06-17.md
+++ b/Meetings/RegularMeetings/2024-06-17.md
@@ -1,0 +1,103 @@
+# WebAgents CG: Regular Meeting (June 17, 2024)
+
+## Agenda
+
+   * Introduction
+       * Introduction of new participants (if any)
+       * Review minutes from the previous meeting
+       * General CG updates
+   * Review of Task Forces
+       * Manageable Affordances Task Force
+       * Use Cases Task Force
+   * Open discussion
+       * Proposals of topics for invited talks
+
+## Participants
+   * Pierre-Antoine Champin
+   * Andrei Ciortea
+   * Rem Collier
+   * Jérémy Lemée
+   * Gustavo Nardin
+   * Antoine Zimmermann
+   * Danai Vachtsevanou
+   * Jesse Wright ([https://github.com/jeswr/](https://github.com/jeswr/), em: jesse.wright@cs.ox.ac.uk)
+   * Jean Paul Calbimonte
+   * Julien Padget
+   * Yousouf Taghzouti
+   * Alexandru Sorici
+
+**Scribe**: Antoine Zimmermann, Rem Collier, Andrei Ciortea
+
+**Notes from previous meeting**: [https://github.com/w3c-cg/webagents/blob/main/Meetings/RegularMeetings/2024-06-06.md](https://github.com/w3c-cg/webagents/blob/main/Meetings/RegularMeetings/2024-06-06.md)
+
+
+## Meeting Notes
+
+New participant: Jesse is a PhD student at the University of Oxford working on semi autonomous web agents (rough proposal [https://drive.google.com/file/d/1CxOtmnVHkChsthX6f9DHu3YGXrgzKyZT/view)](https://drive.google.com/file/d/1CxOtmnVHkChsthX6f9DHu3YGXrgzKyZT/view)), worked on semantic web stuff for 5 yearsr and some W3C specs
+
+Review of minutes from past meeting: we concluded that we will have focused discussions on a topic in order to advance use cases. List of domains for UC discussions: [https://annuel2.framapad.org/p/webagents-uc-tf-areas-a7ed?lang=en](https://annuel2.framapad.org/p/webagents-uc-tf-areas-a7ed?lang=en)
+
+
+### CG updates
+
+TPAC 2024 in California. We will not have enough people to organise a F2F meeting. There will be a meeting in Munich related to WoT where we might join, but we will make an official announcement as detail become available
+
+There will be a workshop on August 29 in Dublin related to WebAgents, but in relation to a COST Action on DKG. We are currently defining a use case to be refined in that workshop. The event will be co-locared and will follow EUMAS 2024: [https://euramas.github.io/eumas2024/](https://euramas.github.io/eumas2024/)
+
+If interested to join the workshop and need funding, COST can help but you need to be invited. Please register at [https://framaforms.org/participation-to-cost-action-dkg-meeting-on-web-agents-1712069231](https://framaforms.org/participation-to-cost-action-dkg-meeting-on-web-agents-1712069231)
+
+
+### Review of Task Forces
+
+**Managable affordances TF**: we have scenarios on Github and now we want to ellicit requirements and then we will do gap analysis. All this will be put in the report
+
+**Use Cases TF**: we only have 2 UCs, but we think we could get UCs from the manageable affordance scenario. To help getting people involved in UC discussion, we are changing strategy and will have focused discussions to build UCs collaboratively. First focused discussion will be on Agriculture on the 25th of July (8 am IST / 9 am CEST). For the next steps, we need to know what people are interested in (see the list of domains in the wiki).
+
+Andrei: UCs should highlight what is different from regular automation UCs.
+
+Alexandru: LLMs \& ML would be interesting for us (with Andrei Olaru), specifically how to share ML models between agents based on needs. E.g. in autonomous driving, sharing driving experience on location between vehicles
+
+Rem: this could be a good topic for a presentation that we can schedule for later
+
+Andrei: we could setup a focused meeting on transportation/traffic/autonomous vehicles
+
+Alex: with LLMs, it is difficult to share the model itself but easy enough to share the content of conversations or the prompts
+
+
+## Open discussion
+
+Starting in autumn, we could have an invited talk per month.
+
+List of topic proposals for future meetings:
+
+- agents sharing learning experience (Alexandru, Jérémy)
+
+- personal assistants \& digital companions (Jesse, Andrei, Antoine)
+
+- LLMs and agents (Julian, Alexandru, Andrei, Jesse)
+
+- embodied AI (Andrei, Rem, Jesse)
+
+
+
+List of use cases proposed for focused meetings:
+
+- industrial manufacturing (Andrei, Antoine)
+
+- building automation (Andrei, Antoine, Rem)
+
+- healthcare / rehabilitation (Jean-Paul, Alexandru, Julian, Rem)
+
+- traffic and mobility (Alexandru, Rem)
+
+Jesse: personal agents UCs on scheduling, booking travel tickets and accommodation, e-commerce
+
+Julian: there is working group IEEE P3394 Standard for Large Language Model Agent Interface. There is some difference of opinion on what "agent" means here.
+
+Andrei: possible topic on embodied AI / embodied agents.
+
+Jean-Paul: interested in healthcare for monitoring and for rehabilitation, physical therapy. Some privacy concerns that could be solved with web agents.
+
+Alex: also a project on monitoring patients, sleep is an important part of it. How to make use of data coming from wearable devices
+
+Above are identified lissts of topics for meetings. For focused discussion, we could identify who is interested and organise an extra meeting with the interested ones.


### PR DESCRIPTION
These are the meeting notes from the regular meeting of the WebAgents CG on 17.06.2024.