### PR TITLE
Add regular meeting notes from 04.07.2024

### DIFF
--- a/Meetings/RegularMeetings/2024-07-04.md
+++ b/Meetings/RegularMeetings/2024-07-04.md
@@ -1,0 +1,85 @@
+# WebAgents CG: Regular Meeting (July 4, 2024)
+
+## Agenda
+
+   * Introduction
+       * Introduction of new participants (if any)
+       * Review minutes from the previous meeting
+       * General CG updates
+   * Review of Task Forces
+       * Manageable Affordances Task Force
+       * Use Cases Task Force
+   * Open discussion
+       * DKG workshop
+
+
+## Participants
+
+   * Antoine Zimmermann
+   * Jérémy Lemée
+   * Simon Mayer
+   * Jean-Paul Calbimonte
+   * Soheil Roshankish
+   * Danai Vachtsevanou
+   * Andrei Ciortea
+
+**Scribe**: Jérémy Lemée
+
+**Notes from previous meeting**: [https://github.com/w3c-cg/webagents/blob/main/Meetings/RegularMeetings/2024-06-17.md](https://github.com/w3c-cg/webagents/blob/main/Meetings/RegularMeetings/2024-06-17.md)
+
+
+## Meeting Notes
+
+New participant: Soheil. PhD student. Background in distributed support (not sure if I caught the word correctly, please correct if needed), normative MAS.
+
+Andrei reviews conclusion of previous meeting. No participation to TPAC but meeting in Munich.
+
+Event in Dublin on August 29.
+
+We are entering holiday period so there will be a fluctuation in participation. 
+
+Participants can add new topic proposals and domain areas. Soheil is invited to add topic proposal on norms.
+
+We are working on Manageable Affordances TF but few progress were made since last meeting. We are working on the requirements. Review of initiatives such as TD and Hydra.
+
+Antoine: Not much progress on Use Case TF. Extra meeting on July 25th on agriculture domain. 
+
+Andrei: New date is required because Rem is no longer available. New date in August or September.
+
+Antoine: Use cases should come from specific domains and Manageable Affordances could also be linked to use cases. Workshop in Dublin. Morning dedicated to presentations and afternoon work on use cases. The topic is Knowledge Graph, what is needed for agents to work autonomously based on information found on the Web as KG.
+
+Andrei: Need to find new dates again. Maybe not August since there will be few participation. 
+
+Ege joins.
+
+Antoine: To participate to workshop, either in Dublin as part of EUMAS or be invited by COST action.
+
+People who have been invited should submit a position statement. Either EasyChair or GitHub can be used.
+
+Andrei: For TPAC, GitHub was used.
+
+Antoine: Let's do it in the same way. 
+
+Discussion on use case with autonomous vacuum cleaner, that relies on a calendar. Another agent can also detect when someone is sleeping. The cleaning happens when no one is sleeping or having a videoconference. 
+
+Andrei: Main features to highlight in the use case? Manipulation of KG?
+
+Antoine: The way to solve the use case should be as flexible as possible. The vacuum cleaner should not need to be reconfigured for working in a new environment, only the KG should change. 
+
+Andrei puts link to workshop agenda in the chat: [https://github.com/w3c-cg/webagents/tree/main/Meetings/2024-08-29-DKG-workshop](https://github.com/w3c-cg/webagents/tree/main/Meetings/2024-08-29-DKG-workshop)
+
+Simon agrees to have the meeting in September.
+
+Small discussion about when to have the meeting. Conclusion: most likely September.
+
+Andrei: We need more content to regular meeting. Proposition: demo of article that wil be presented at EUMAS on toolkits. All participants are invited to do presentations.
+
+Soheil: Work on model of norms, good feedback on adding time constraints to normative systems (shared articles: [https://link.springer.com/chapter/10.1007/978-3-031-16617-4\_2](https://link.springer.com/chapter/10.1007/978-3-031-16617-4\_2) and [https://link.springer.com/chapter/10.1007/978-3-031-20614-6\_20)](https://link.springer.com/chapter/10.1007/978-3-031-20614-6\_20)).
+
+Andrei: Great to add Soheil's presentation for a meeting after end of August, when Soheil is available. 
+
+Andrei: Hands-on stuff would be good to show. These demos could be organized during July or August when participation is flutuating. 
+
+Antoine: New pull requests for workshop. 
+
+Andrei: End of meeting


### PR DESCRIPTION
These are the meeting notes from the regular meeting of the WebAgents CG on 04.07.2024.