### PR TITLE
Add regular meeting notes from 30.09.2024

### DIFF
--- a/Meetings/RegularMeetings/2024-09-30.md
+++ b/Meetings/RegularMeetings/2024-09-30.md
@@ -1,0 +1,93 @@
+# WebAgents CG: Regular Meeting (Sep. 30, 2024)
+
+## Agenda
+   * Introduction
+       * Introduction of new participants (if any)
+       * Review minutes from the previous meeting
+       * General CG updates
+   * Review of Task Forces
+       * Manageable Affordances Task Force
+       * Use Cases Task Force
+   * Open discussion
+       * WoT Week 2024
+
+## Participants
+   * Samuele Burattini
+   * Jean-Paul Calbimonte
+   * Arthur Casals
+   * Rem Collier
+   * Ege Korkan
+   * Jérémy Lemée
+   * Andrei Olaru
+   * Danai Vachtsevanou
+   * Jesse Wright
+   * Antoine Zimmermann
+
+**Scribe**: Ege
+
+**Notes from previous meeting**: [https://github.com/w3c-cg/webagents/blob/main/Meetings/RegularMeetings/2024-09-19.md](https://github.com/w3c-cg/webagents/blob/main/Meetings/RegularMeetings/2024-09-19.md) (19th September)
+
+
+## Meeting Notes
+
+Arthur: I have been here before but I haven't attended a meting for the past 2-3 months. I do multi-agents research.
+
+Andrei: I am a colleague of Alexandru Sorici and ex colleague of Andrei Ciortea. I do research on multi agent systems. At the university, we are building a multi-agent system framework.
+
+### Minutes Review
+
+Antoine: We forgot to review the minutes from last time. I am sharing the link in the notes. If anyone has concerns, please leave a comment over github via issue or PR.
+
+### Updates from the Task Forces
+
+Ege: no update from the manageable affordances
+
+Antoine: There will be a session about healthcare and rehab. The date is not final yet but we will communicate it once that is done. The job of the use case the TF is to build a discussion around a specific theme. That way, we can get use cases out of the discussion.
+
+Samuele: Is there an issue for the use case?
+
+Antoine: It is not a use case, it is a domain of interest. So we changed our strategy to get interest on a domain. In the notes of June 17th, there is a list with names assigned. Healthcare was one of those topics and had 4 names so we decided to start with it.
+
+### WoT Week (25-29 Nov. 2024, Munich, Germany)
+
+Note: The WoT week is related to the W3C WoT working group but is of interest to the Webagents CG because there are use cases for having Agents interacting with Web things.
+
+Ege: asked who knows about WoT Week
+
+Ege: Last Week of Nov - WoT Week in Germany (Siemens / Microsoft) - details in the link: [https://www.w3.org/WoT/IG/wiki/Wiki\_for\_WoT\_Week\_2024\_planning](https://www.w3.org/WoT/IG/wiki/Wiki\_for\_WoT\_Week\_2024\_planning)
+
+Ege: Monday/Tuesday is a Plugfest - Idea: Bring device or thing that is defined or consumes WoT Standards; Wed is a showcase event (pitches + company engagement)
+
+Ege: Discussed WebAgents engagement with WoT Week \& offered potential to participate
+
+Jessie: 50% sure to join.
+
+Samuele \& Antoine: Will join online
+
+Ege: List of things being brought to the Hackathon ([https://github.com/w3c/wot-testing/tree/main/events/2024.11.Munich)](https://github.com/w3c/wot-testing/tree/main/events/2024.11.Munich))
+
+Rem will bring a demo of ASTRA/MAMS
+
+Jérémy will provide a demo of Yggdrasil (software only)
+
+Ege: There will be around 7 in person + online, so we will hold a WebAgents meeting in parallel to the event.,
+
+Antoine: wherever possible, identify potential use case for Web agents. Web things could be agents themselves when they are proactive, but may just be artifacts used by software agents
+
+Ege: opportunity to test the limits of the integration
+
+Danai: Ygdrassil can interact via CoAP, but the main platform is based on HTTP
+
+Danai: What is the most expected format of Thing Descriptions
+
+Ege: Mainly JSON-LD; do not expect turtle
+
+Ege: JSON-LD group restarting and working on YAML and ???. Showed some example TDs from the 2022/06 event
+
+Ege: Does anybody want to be involved in the standardisation days?
+
+Ege: Will send an invite to participants.
+
+Antoine: Any more comments / AOB?
+
+The crowd: *Silence*


### PR DESCRIPTION
These are the meeting notes from the regular meeting of the WebAgents CG on 30.09.2024.