### PR TITLE
Add regular meeting notes from 28.10.2024

### DIFF
--- a/Meetings/RegularMeetings/2024-10-28.md
+++ b/Meetings/RegularMeetings/2024-10-28.md
@@ -1,0 +1,131 @@
+# WebAgents CG: Regular Meeting (Oct. 28, 2024)
+
+## Agenda
+   * Introduction
+       * Introduction of new participants (if any)
+       * Review minutes from the previous meeting
+       * General CG updates
+   * Review of Task Forces
+       * Manageable Affordances Task Force
+       * Use Cases Task Force
+   * Open discussion
+       * WoT Week 2024
+
+## Participants
+   * Antoine Zimmermann
+   * Terry Payne
+   * Andrei Ciortea
+   * Jesse Wright
+   * Soheil Roshankish
+   * Samuele Burattini
+   * Jean-Paul Calbimonte
+   * Danai Vachtsevanou
+   * Ege Korkan
+
+**Scribe**: Antoine \& Andrei
+
+**Notes from previous meeting**: [https://github.com/w3c-cg/webagents/blob/main/Meetings/RegularMeetings/2024-10-17/2024-10-17.md](https://github.com/w3c-cg/webagents/blob/main/Meetings/RegularMeetings/2024-10-17/2024-10-17.md)
+
+## Meeting Notes
+
+Soheil: PhD at university ? Switzerland, defended August, then working with Nicoletta Fornara. PhD topic on MAS, framework for monitoring norms and policies in the Web of Data. Translating human readable norms to machine-readable for agents.
+
+Jesse: What do you mean by policies in your research?
+
+Soheil: Focus of my research is on social norms and relation norms, not so much policies.
+
+Here you can find some of Soheil's works: [https://scholar.google.com/citations?user=mkaQS\_IAAAAJ\&hl=en](https://scholar.google.com/citations?user=mkaQS\_IAAAAJ\&hl=en)
+
+Terry: prof at univ. Liverpool, UK, bring semantic web + MAS, looking at protocols and processes for agents to reach a form of alignments. Now considering competency questions, essential to knowledge engineering, exploring use of LLMs for that.
+
+AZ: I attended the Linked Web Storage WG and WebAgents were mentioned quite often in this WG, the Dagstuhl seminars as well. It's interesting that we keep an eye out. It only started today with the 2nd meeting and it will meet on Mondays. The meetings are at the same time with our Monday meetings. The focus right now is to collect use cases. Perhaps we can provide a use case for using Web storage for Web agents.
+
+Terry: What do you mean by storage in this context?
+
+AZ: What I have in mind is a Solid data pod. IMO, the way I see it is that the working group is not going to standardize the storage itself but the protocol to talk with the storage. They want a protocol that works with Solid but is more general.
+
+Andrei: isn't Solid based on the Linked Data Platform (LDP), which is a W3C Recommendation, and thus LWS would build on top of it?
+
+AZ: not necessarily but maybe. I am not aware of the alternatives to Solid that could play a role in the WG. But in my mind, I think of Web storage as in Solid Pods, which builds on LDP
+
+Andrei: there was a good discussion on UCs for heathcare and rehab, but we need to have additional meeting(s). 
+
+(Interuption: we approve previous meeting minutes)
+
+## Review of Task Forces
+
+### Manageable affordances TF
+
+Andrei: strong connections with the WoT working group. We are preparing a CG report on this TF. Manageable affordances are long running actions or processes that "things" may be triggered to do. But it's not only about things, as in "The Web of *Things*".
+
+Andrei, we will have a meeting during the WoT week in Munich (more on this later in this meeting)
+
+### UC TF
+
+AZ: Last meeting was dedicated to UC discussions, as already said.
+
+We need more discussion on the topic of health care, and we will pick a date for this. 
+
+We also want to start other discussion threads on other topics identified. Don't hesitate to reach out to Antoine or Rem
+
+## Open Discussion: WoT Week in Munich
+
+Andrei: Siemens is organising it in relation to the WoT WG
+
+... There will be Working Group meetings (reserved for WG members)  + a plugfest open to others
+
+... A plugfest is an event where people test implementations of WoT ecosystems
+
+... there will be sessions where peopel showcase their demo
+
+... some of us in the CG will be presenting things with Agents and things
+
+... There will be a WebAgents face to face meeting too
+
+... We arranged it such that peopel of the WoT WG can join the WebAgents CG meeting
+
+... online participation (in the plugfest) is possible if you have an application to show but can't travel
+
+### WoT Week 2024
+
+Agenda: [https://www.w3.org/WoT/IG/wiki/Wiki\_for\_WoT\_Week\_2024\_planning](https://www.w3.org/WoT/IG/wiki/Wiki\_for\_WoT\_Week\_2024\_planning)
+
+Soheil: is it possible to participate online even when we don't have an application, just to see what is being done
+
+Andrei: you can travel to Munich for the F2F meeting, which is open to anyone. For the online participation to the plugfest, ask Ege
+
+Andrei: everything will be published on Github
+
+### F2F meeting
+
+Andrei: We have a high level agenda: 
+
+- Review of the activity of the CG [30 min]
+
+- Updates and feedback from PlugFest participants [30 min]
+
+- Open discussion: Challenges \& opportunities, Use Cases for agents [1h]
+
+Samuele: would the WoT group also bring some content to the face-to-face meeting about usecases/requirements for autonomy or flexibility?
+
+Andrei: There was a joint meeting at TPAC last year between the WebAgents CG and the WoT WG, and one of the main points that came out was the Use Cases TF. We had a very good and active discussion with the WoT WG and there is good interest, but the discussion was also necessarily high-level given the limited time. The WebAgents CG should take lead in defining use cases for agents in WoT enviornments and we can loop in members of the WoT WG to ground the use cases. We should organize another joint meeting with the WoT WG as soon as we have the first report from the Use Cases TF.
+
+Ege: a question we need to address in WoT is how to introduce proactive entities in a WoT setting
+
+Andrei: these discussions should be led by the WebAgents CG
+
+Andrei; going back to participation in the plugfest, can peopel participate even if they don't have something to show
+
+Ege: yes it's possible for the event in Monday and Tuesday
+
+ ... Wednesday requires registration
+
+Agenda for Wednesday: [https://wot-conference.events.dc.siemens.com/registrations/4656c284-196e-4af4-865f-060b0af4364a/landing-page](https://wot-conference.events.dc.siemens.com/registrations/4656c284-196e-4af4-865f-060b0af4364a/landing-page)
+
+Ege: participating online to the plugfest is possible but it may be hard to follow anything. If you have a device or applciation, then it makes sense
+
+Andrei: (review of the WoT meeting agenda)
+
+Ege: the WoT meeting on Wednesday will not be open to online participants
+
+Andrei: from St Gallen, neither Andrei nor Simon will be able to go there. Jérémy Lemée and Kai Schultz will be joining from our group with demos.


### PR DESCRIPTION
These are the meeting notes from the regular meeting of the WebAgents CG on 28.10.2024.