### PR TITLE
Add regular meeting notes from 16.01.2025

### DIFF
--- a/Meetings/RegularMeetings/2025-01-16.md
+++ b/Meetings/RegularMeetings/2025-01-16.md
@@ -1,0 +1,127 @@
+
+# WebAgents CG: Regular Meeting (Jan. 16, 2025)
+
+## Agenda
+   * Introduction
+       * Introduction of new participants (if any)
+       * Review minutes from the previous meeting
+       * General CG updates
+   * Review of Task Forces
+   * Open discussion
+       * Interoperability Task Force
+           * Initial description: [https://github.com/w3c-cg/webagents/tree/tf-interoperability/TaskForces/Interoperability](https://github.com/w3c-cg/webagents/tree/tf-interoperability/TaskForces/Interoperability) 
+           * Feedback: [https://github.com/w3c-cg/webagents/pull/70](https://github.com/w3c-cg/webagents/pull/70)
+       * Embodiment in Hypermedia Environments
+
+## Participants
+   * Andrei Ciortea
+   * Rem Collier
+   * Gaowei Chang
+   * Danai Vachtsevanou
+   * Jérémy Lemée
+   * Soheil Roshankish
+   * Andrei Olaru
+   * Antoine Zimmermann
+   * Julian Padget
+   * Jean-Paul Calbimonte
+   * Samuele Burattini
+   * Simon Mayer
+   * Jesse Wright
+**Scribe**: Rem Collier
+
+**Notes from previous meeting**: [https://github.com/w3c-cg/webagents/tree/main/Meetings/RegularMeetings/2024-12-12](https://github.com/w3c-cg/webagents/tree/main/Meetings/RegularMeetings/2024-12-12)
+
+## Meeting Notes
+
+[AC] Introduction of new members
+
+[GC] Presented himself "Here is my open source project: [https://github.com/chgaowei/AgentNetworkProtocol](https://github.com/chgaowei/AgentNetworkProtocol), and agent communication protocol."
+
+[AC]  Agenda presented \& highlights poll for new timeslots
+
+       * [https://evento.renater.fr/survey/webagents-cg-regular-meetings-2025-4oua6eau](https://evento.renater.fr/survey/webagents-cg-regular-meetings-2025-4oua6eau)
+[AC] REview of minutes from last meeting
+
+[AC] Good discussion around evolution, cognitive stigmery, ...
+
+[AC] Submitted a proposal for HyperAgents @ ECAI 2025
+
+[AC] Supplement workshop with F2F meeting \& possibly PlugFest
+
+[AC] Introduces the main topic: Interoperabilty TF (proposed TF description at [https://github.com/w3c-cg/webagents/tree/tf-interoperability/TaskForces/Interoperability)](https://github.com/w3c-cg/webagents/tree/tf-interoperability/TaskForces/Interoperability))
+
+[AC] History FIPA Standards \& reference platform: AgentCities
+
+[AC] Asked about experiences
+
+[RC] Good demonstration of interoperatbility but lack of use cases / practical deployments
+
+[JP] Described one deployment around Tourism \& mentioned he has slides on other initiatives
+
+[AC] Moved on to discuss DARPA DAML Project and impact on Semantic.Web
+
+[AC] Overview of main topics (as per TF description)
+
+[AZ] Some use cases from Linked Web Storage Working Group are relevant to WebAgents CG
+
+       * [https://github.com/w3c/lws-ucs/issues](https://github.com/w3c/lws-ucs/issues)
+       * Also, there is an ongoing discussion on Agentic Linked Data on the Solid CG: [https://lists.w3.org/Archives/Public/public-solid/2025Jan/0001.html](https://lists.w3.org/Archives/Public/public-solid/2025Jan/0001.html)
+[AC] Number of possible existing standards could be used.
+
+[AC] Discussing some of the standards
+
+[AC] Plan is for monthly meetings + async interactions
+
+[RC] We had meetings to discuss UCs in specific topics (e.g. healthcare)
+
+[AO] Questioned the existence of Use cases
+
+[AC] We have a TF for that
+
+[AO] Interested to demo FlashMAS
+
+[RC] The Use Cases TF needs more support to drive the development of use cases
+
+[AC] Talked about the lack of engagement, our original plan to get members to submit full Use Case descriptions and the switch to focus groups
+
+
+
+[AC] gives first example: Yggdrasil
+
+
+
+Relevant papers:
+
+- Ciortea, A., Boissier, O., Ricci, A. (2019). Engineering World-Wide Multi-Agent Systems with Hypermedia. In: Weyns, D., Mascardi, V., Ricci, A. (eds) Engineering Multi-Agent Systems. EMAS 2018. Lecture Notes in Computer Science(), vol 11375. Springer, Cham. [https://doi.org/10.1007/978-3-030-25693-7\_15](https://doi.org/10.1007/978-3-030-25693-7\_15)
+
+- Danai Vachtsevanou, Andrei Ciortea, Simon Mayer, and Jérémy Lemée. 2023. Signifiers as a First-class Abstraction in Hypermedia Multi-Agent Systems. In Proceedings of the 2023 International Conference on Autonomous Agents and Multiagent Systems (AAMAS '23). International Foundation for Autonomous Agents and Multiagent Systems, Richland, SC, 1200–1208. [https://dl.acm.org/doi/abs/10.5555/3545946.3598763](https://dl.acm.org/doi/abs/10.5555/3545946.3598763)
+
+
+
+[AC] Mentions a second demo that demonstrates agent profiles
+
+[AO] Where do we see the Thing artifact being used?
+
+[AC] Shows the creation of Thing artifact \& highlights a number of libraries that they have used to deliver the funvtionality.
+
+[AO] how do you discover actions / how do you invoke actions
+
+[AC] the invokeAction(...) CArtAgO operation.
+
+[RC] perhaps start to move to wrapup
+
+[AC] summarising demo
+
+[RC] start to put some of these libraries on our resources section.
+
+[AC] back to Interoperability TF
+
+[AC] Web is not just a transport layer for agent communication, the Web can be come the application layer/environment for MAS
+
+[RC] Who will get involved in the Interoperability TF?
+
+[DC] Will engage
+
+[AO] Will engage
+
+[AZ] Will engage


### PR DESCRIPTION
These are the meeting notes from the regular meeting of the WebAgents CG on 16.01.2025.