### PR TITLE
Add regular meeting notes from 27.01.2025

### DIFF
--- a/Meetings/RegularMeetings/2025-01-27.md
+++ b/Meetings/RegularMeetings/2025-01-27.md
@@ -1,0 +1,112 @@
+# WebAgents CG: Regular Meeting (Jan. 27, 2025)
+
+## Agenda
+   * Introduction
+       * Introduction of new participants (if any)
+       * Review minutes from the previous meeting
+       * General CG updates
+   * Review of Task Forces
+   * Open discussion
+       * Embodiment in Hypermedia Environments (continued)
+
+## Participants
+   * Katharine Beaumont
+   * Samuele Burattini
+   * Andrei Ciortea
+   * Rem Collier
+   * Josh Cornejo
+   * Anastasiya Danilenka
+   * Ege Korkan
+   * Jérémy Lemée
+   * Simon Mayer
+   * Andrei Olaru
+   * Terry Payne
+   * Alexandru Sorici
+   * Piotr Sowiński
+   * Danai Vachtsevanou
+   * Antoine Zimmermann
+**Scribe**: Antoine Zimmermann
+
+Notes from previous meeting: [https://github.com/w3c-cg/webagents/commit/7254aa4df04d4a29dcbf4f7ef47e13a99cf6e431](https://github.com/w3c-cg/webagents/commit/7254aa4df04d4a29dcbf4f7ef47e13a99cf6e431)
+
+## Meeting Notes
+
+### Introduction
+
+#### New participants
+
+Piotr: cofounder of Polish startup NeverBlink related to/interested in KGs and Web agents
+
+Anastasiya: same company, I am very interested in Web agents
+
+Terry: was already at some Web agents CG meeting but not in a long time. SemWeb, agents, services, OWL-S long ago, interest in agents and their collaboration, MAS
+
+Josh: from the UK, in the ODRL WG, control of agents has surfaced in my group.
+
+#### Review of minutes
+
+approved
+
+#### General CG updates
+
+--> new schedule for the regular meetings. Monday every 4 weeks from now at 17:00 CET and Friday every 4 weeks from Feb. 14th at 9:00 CET. The best way to be up to date is to subscribe to the CG calendar at [https://www.w3.org/groups/cg/webagents/calendar/](https://www.w3.org/groups/cg/webagents/calendar/) (see bottom of the page)
+
+--> Also, new policy of changing chairs of the meetings 
+
+### Task forces
+
+#### Manageable affordances
+
+Andrei C.: Writing a UC on building automation with Ganesh (Siemens), Simon (University of St.Gallen) and Danai (University of St.Gallen). Once ready, we'll propose to organize a focused discussion on building automation as an application area.
+
+Ege: Manageable affordances TF is about taking interactions with a device that needs to be managed over time (as opposed to simple request-response). This is of interest to Web of Things too. Many IoT use cases. We will produce a report.
+
+#### Use cases
+
+Rem: we are gathering UCs which is more long term than what's collected at the manageable affordances TF level
+
+#### [NEW!] Interoperability
+
+New TF presented last time. Initial description available on GitHub, see PR 70 for feedback and comments: [https://github.com/w3c-cg/webagents/pull/70](https://github.com/w3c-cg/webagents/pull/70)
+
+Presentation from Rem about MAMS (link to be added afterwards)
+
+> MAMS combine technologies from multiagent systems \& hypermedia by way of Microservices that hide the MAS technologies as in a black box
+
+Rem also presents a demo of an implemented MAMS use case (Auction).
+
+Andrei O.: slide with the diagramme with container and agent. Why do microservices have to go to the manager? why not directly to the agents?
+
+Rem: not always. E.g. MS1 knows about the bidder.
+
+Andrei O.: who translates HTTP requests to and from FIPA ACL?
+
+Rem: it's not HTTP requests that are translated, it is the content (payload) that's translated inside the service. There is an artifact (Rem shows Java code explaining how the artifact is implemented). See the public repo: [https://gitlab.com/mams-ucd/mams-cartago](https://gitlab.com/mams-ucd/mams-cartago)
+
+Andrei O. and Rem will talk offline and possibly report about their conversation in a future meeting.
+
+Danai: [scribe missed question]?
+
+Rem: we use HAL but I think an RDf-based solution would be superior. We plan to implement a version with RDF.
+
+Jérémy: RDF allows expressing more than HAL?
+
+Rem: in HAL, you don't have a way to define shared vocabularies and ontologies \& JSON schema is not as rich as RDF for this.
+
+Jérémy: what's HAL more used for?
+
+Rem: makers of HAL wanted to build more proper APIs.
+
+Jérémy: What's "profile"?
+
+Rem: it's for indicating the JSON schema of the data inside the JSON snippet.
+
+Piotr: re. the diagramme, what does Akka does not solve?
+
+Rem: with agent-based architecture you have much richer possibilities with more types of messages, interraction with environment, goals, etc. And there are different types of agents architectures (e.g., BDI ...)
+
+There will be a presentation in 2 weeks about the agent network protocole.
+
+### Open discussion
+
+No time remaining for this.


### PR DESCRIPTION
These are the meeting notes from the regular meeting of the WebAgents CG on 27.01.2025.