### PR TITLE
Add regular meeting notes from 16.06.2025

### DIFF
--- a/Meetings/RegularMeetings/2025-06-16.md
+++ b/Meetings/RegularMeetings/2025-06-16.md
@@ -1,0 +1,92 @@
+# WebAgents CG: Regular Meeting (June 16, 2025)
+
+## Agenda
+
+   * Introduction
+       * Introduction of new participants (if any)
+       * Review minutes from the previous meeting
+       * General CG updates
+   * Quick review of TFs
+   * Open discussion 
+       * Participation at TPAC 2025
+       * Face-to-Face meeting in Bologna; joint meeting w/ HyperAgents workshop @ ECAI 2025
+       * Interoperability TF: continue the discussion of the Interoperability TF report
+
+## Participants
+
+   * Andrei Ciortea (chair)
+   * Ege Korkan
+   * Arthur Casals
+   * Jérémy Lemée
+   * Lorenzo Moriondo
+   * Raza NAQVI
+   * Danai Vachtsevanou
+   * Rem Collier
+   * Julian Padget
+   * Dirk Schnelle-Walka
+
+## Regrets
+
+   * Antoine Zimmermann
+
+**Scribe**: Jérémy Lemée
+
+**Notes from previous meeting**: [https://github.com/w3c-cg/webagents/pull/84](https://github.com/w3c-cg/webagents/pull/84)
+
+## Meeting Notes
+
+Andrei: Introduction of new participants
+
+Lorenzo: from London, has been working with Markus Lanthaler, creator of JSON-LD to work on W3C Hydra WG. In 2019, has mentored Google Summer of Code, with some work on automated clients working with Hydra. Github repository to Hydra Ecosystem, a set of tools to leverage the W3C Hydra standard in Python, at [https://github.com/http-apis](https://github.com/http-apis) also Heracles, an automated client working with Hydra servers [https://github.com/HydraCG/Heracles.ts](https://github.com/HydraCG/Heracles.ts)
+
+Dirk: in Germany, preparing a workshop for smart voice agents
+
+Andrei: review of the meeting notes from last time: [https://github.com/w3c-cg/webagents/pull/84/commits/f9380110710e2b17a7f60892686ed72b46e93954](https://github.com/w3c-cg/webagents/pull/84/commits/f9380110710e2b17a7f60892686ed72b46e93954)
+
+Andrei: preparation of the report on interoperability. Relevant to an issue to organize a workshop on agents on the Web. Mentions the GitHub project: [https://github.com/w3c-cg/webagents](https://github.com/w3c-cg/webagents). It is possible to contribute indirectly by issues or directly by pull request. Advice to link W3C account with GitHub. There is already an issue and a pull request. Open points on the meeting notes from last time? No answer.
+
+Andrei: presents [https://ecai2025.hyperagents.org/](https://ecai2025.hyperagents.org/), with an extension deadline of 2 weeks. 
+
+Andrei: The Manageable Affordances TF has been put on hold for the past few months in order to focus on interoperability TF. However, the Web of Things community has growing interest on manageable affordances. The purpose of this TF is to study long running actions. Mentions Danai has one the people who is best positioned to advance the discussion. The scope of the TF is broader than the Web of Things, scholarly publications is also within the scope of the TF. There is also a report for the Manageable Affordance TF about the scenarios that have been discussed so far and discussion of available standards and what is missing.
+
+Danai: Asks for pointers towards discussion in WoT
+
+Andrei: Provides link: [https://github.com/w3c/wot-thing-description/pull/2107](https://github.com/w3c/wot-thing-description/pull/2107), which is the gist of the discussion of manageable affordances in the WoT CG.
+
+Andrei: Next item: TPAC. Ege provided a form ([https://docs.google.com/forms/d/e/1FAIpQLScJp87dtb0HnXEnY8lsArCkFzf489GKFZ7PQj5KRY670s0bZw/viewform)](https://docs.google.com/forms/d/e/1FAIpQLScJp87dtb0HnXEnY8lsArCkFzf489GKFZ7PQj5KRY670s0bZw/viewform)) to indicate interest in the event. Good to organize an in-person meeting if at least 3 people join on site. Potential to organize joint meeting with other groups (maybe Web of Things WG and AI Agent Network Protocol CG). By then, we should have completed or be nearly done with the report so that it could be presented to the broader Web community. Our input to Ege's form is important so we all need to fill it.
+
+Andrei: Face to face meeting before the HyperAgents workshop in Bologna where we could show some demonstrations. Perhaps, we could also organize a hackathon. This would provide input to the Interoperability TF. Also, a meeting to discuss the direction of the CG.
+
+Andrei: The Interoperability TF report should answer the role of the Web for Multi-Agent Systems and the role of the W3C (and its standards) for Multi-Agent Systems. The structure of the report is inspired from a report by the social web CG. The Visions of Agents on the Web section is already written and feedback is welcome.
+
+Andrei: I was recently pointed to an initiative from IBM called Bee AI that builds on MCP and should be included in the report ([https://research.ibm.com/blog/multiagent-bee-ai)](https://research.ibm.com/blog/multiagent-bee-ai)). Feedback and contribution are welcome for the state of the art and the table.
+
+Discussion with Lorenzo to invite him to contribute inputs on architectural considerations. Discussion of the section that has been contributed to the report on interface-level interoperability. Andrei suggests some of this could be included within agents and the decentralized social web. The section on Agentic AI is about new recent developments in AI. Something like Langchain would not be fit for the report but MCP would be but another report could be about frameworks to program agents (so Langchain would fit there).
+
+Julian provides link to [https://standards.ieee.org/ieee/3394/11377/](https://standards.ieee.org/ieee/3394/11377/) as relevant. Andrei acknowledges that this is indeed relevant.
+
+Web-based MAS are typically merged in bottom up fashion using the Web standards of the time. The report would bring a top down conceptual view on how MAS should work. We can use the 4 dimensions of MAS (agent, environment, organization, interaction) to position different contributions (so MCP is at environment level, A2A interaction, ODRL for policies so maybe the organization level). This approach brings conceptual coherence to the proposed initiatives.
+
+Ege: examples should be provided to bring together a practical use case with the different dimensions and illustrate the use of these dimensions. Ege mentions systems of cars on the road. 
+
+Andrei: the boundaries between the dimensions are not clear-cut but are still useful to consider.
+
+Julian: This model of dimensions is one possible view but other views are possible
+
+Andrei: The model is very asbtract and should be instantiated for Web-based MAS. However, it helps to organize the discussion.
+
+Terry: The terminology of the concepts used in the diagram should be clarified.
+
+Andrei notes he added the keywords in the diagram but needs revision.
+
+Rem: Agreement that the diagram is a good starting point for discussion
+
+Andrei: mentions the diagram used by A2A and its positioning with MCP. It provides a clear positioning between the 2 protocols and their relation withe Agent-Agent interaction and Agent-Environment interaction. What would be a conceptual model for a Web-based MAS? Discussion with Ege on profiles. Profiles are part of the environment. Andrei will create new diagram or new version of the diagram.
+
+Andrei: More refined structure since last meeting for the different sections. Andrei provide link to this report ([https://www.w3.org/2005/Incubator/socialweb/XGR-socialweb-20101206/)](https://www.w3.org/2005/Incubator/socialweb/XGR-socialweb-20101206/)) which influenced the structure of out own. For the next meeting, it would be good to provide feedback or contribute to the report.
+
+Ege: Explain [https://github.com/w3c/wot-thing-description/pull/2107](https://github.com/w3c/wot-thing-description/pull/2107). A report from the WoT group ([https://github.com/w3c/wot-thing-description/blob/3994dfdfb49b8192f5c838d6822e3272f8a1f892/planning/work-items/analysis/analysis-manageable-affordances.md)refers](https://github.com/w3c/wot-thing-description/blob/3994dfdfb49b8192f5c838d6822e3272f8a1f892/planning/work-items/analysis/analysis-manageable-affordances.md)refers) to the scenarios from our WebAgents CG. 
+
+Andrei and Ege: idea to organize a joint meeting. 
+
+Andrei: thanks everyone, mentions that external presentations (e.g, from IBM BeeAI) could be organized.


### PR DESCRIPTION
These are the meeting notes from the regular meeting of the WebAgents CG on 16.06.2025.