### PR TITLE
Add regular meeting notes from 11.08.2025

### DIFF
--- a/Meetings/RegularMeetings/2025-08-11.md
+++ b/Meetings/RegularMeetings/2025-08-11.md
@@ -1,0 +1,57 @@
+# WebAgents CG: Regular Meeting (Aug 11, 2025)
+
+## Agenda
+
+   * Introduction
+       * Introduction of new participants (if any)
+       * Review minutes from the previous meeting
+       * General CG updates
+   * Review of Task Forces
+   * Open discussion
+       * Interoperability report
+
+## Participants
+
+   * Andrei Ciortea
+   * Jérémy Lemée
+   * Andrei Olaru
+
+## Regrets
+
+   * Rem Collier
+
+**Scribe**: Jérémy Lemée
+
+**Notes from previous meeting**: [https://github.com/w3c-cg/webagents/pull/90](https://github.com/w3c-cg/webagents/pull/90)
+
+**Invited talk recording**: [https://youtu.be/LpAC-sipBvA](https://youtu.be/LpAC-sipBvA)
+
+## Meeting Notes
+
+### General updates
+
+Agent Toolkits community session @ EUMAS 2025 (online attendance is possible; registration by Aug 20): [https://interactions.ics.unisg.ch/agent-toolkits-2025/](https://interactions.ics.unisg.ch/agent-toolkits-2025/)
+
+HyperAgents 2025 @ ECAI 2025 — accepted papers now listed: [https://ecai2025.hyperagents.org/](https://ecai2025.hyperagents.org/)
+
+### Open discussion
+
+Previous meeting: talk by Amit Chopra that was recorded (see link above). 
+
+Agent Toolitis Web page online with the position statements (see link above). The registration for the Agents Toolkit community session should be made by Aug 20 (see link above).
+
+Accepted papers for HyperAgents are also online (see link above).
+
+Hybrid session at the TPAC (registration process + registration fee). Link: [https://www.w3.org/2025/11/TPAC/](https://www.w3.org/2025/11/TPAC/)
+
+We had a good discussion with WoT WG on Manageable Affordances. We'll follow through for updates.
+
+Interoperability TF report in preparation. The report bridges the gap between the research community and the broader W3C community. The report defines the concepts used.
+
+Discussion concerning the definitions.
+
+Presentation of conceptual dimensions ([https://deploy-preview-88--w3cwebagentscg.netlify.app/)](https://deploy-preview-88--w3cwebagentscg.netlify.app/)). Andrei asks for feedback on the conceptual dimensions.
+
+Discussion on open MAS and language agents in closed vs open MAS. Most applications of language/augmented language models are currently in closed systems, even when using protocols like MCP that can be used in open systems.
+
+Discussion of the 5 stars of Linked Data as a path to move from closed MAS to open MAS.


### PR DESCRIPTION
These are the meeting notes from the regular meeting of the WebAgents CG on 11.08.2025.