### PR TITLE
Add regular meeting notes from 29.08.2025

### DIFF
--- a/Meetings/RegularMeetings/2025-08-29.md
+++ b/Meetings/RegularMeetings/2025-08-29.md
@@ -1,0 +1,70 @@
+# WebAgents CG: Regular Meeting (Aug 29, 2025)
+
+## Agenda
+
+   * Introduction
+       * Introduction of new participants (if any)
+       * Review minutes from the previous meeting
+       * General CG updates
+   * Review of Task Forces
+   * Open discussion
+       * Interoperability report
+
+## Participants
+
+   * Andrei Ciortea
+   * Jérémy Lemée
+   * Antoine Zimmermann
+   * Rem Collier
+   * Andrei Olaru
+   * Stephen Cranefield
+   * Jean-Paul Calbimonte
+   * Soheil Roshankish
+   * Julian Padget
+   * Simon Mayer
+
+## Regrets
+
+   * Ege Korkan
+
+**Scribe**: Rem Collier
+
+**Notes from previous meeting**: [https://github.com/w3c-cg/webagents/pull/91](https://github.com/w3c-cg/webagents/pull/91)
+
+## Meeting Notes
+
+AZ: \& AC: Discuss advertisement of CG meetings
+
+AC: People interested in participating in the Agent Toolkits community session at EUMAS and not already registered should write to eumas2025@upb.ro
+
+AC: The Last meeting was a small group. The main focus was on the review and consolidation of the Interoperability report.
+
+[https://w3c-cg.github.io/webagents/TaskForces/Interoperability/Reports/report-interoperability.html#architectural-considerations](https://w3c-cg.github.io/webagents/TaskForces/Interoperability/Reports/report-interoperability.html#architectural-considerations)
+
+AC: We'll be present at TPAC 2025. Mostly online, Ege will be on-site. The session will take place in the afternoon of November 10th for 1 hour.. To attend online, you must also register (90€).
+
+AC: TPAC Link: [https://www.w3.org/2025/11/TPAC/schedule.html](https://www.w3.org/2025/11/TPAC/schedule.html)
+
+AC: ANP Community Group will have a session as well. It could be a good opportunity to meet.
+
+AC: HyperAgents workshop update -strong interest - currently scheduled for 1/2 day but full day requested ([https://ecai2025.hyperagents.org/)](https://ecai2025.hyperagents.org/)). We are happy to announce Terry Payne will give the opening keynote. If we get more time, we'll also organize a panel.
+
+AC: Opportunity for a hybrid WebAgents CG event on the same day or the day before, depending on the final schedule.
+
+AC: A number of people from the group will be attending in person.
+
+AC:  Noving on to interoperability report
+
+AC: Sections 3.1 \& 3.2 are nearing final forms. Also opened a draft pull request for architectural considerations to be discussed today ([https://github.com/w3c-cg/webagents/pull/92)](https://github.com/w3c-cg/webagents/pull/92))
+
+AC: Looking at Section 2 - interesting point related to Augmented Language Model which seems to incorporate  Situatedness..
+
+AC: Discussing Section 3.1 - history of agents on the web (AgentCitites, DARPA CoABS, ...) and the more recent discussions in the last 5 years (Dagstuhl)
+
+AC: Moving on to section 3.2 -  discussing the different dimensions that must be considered when discussing multi-agent systems. Mentions the move from the web as a transport layer for communication (interaction)  towards the emergence of the web as an environment.
+
+AC: Long discussion around the architectural considerations section.. Discussion of the design goals (referenced DID design goals as an example of the type of information to be used).  For architectural patterns, AC was showing sections of the book "Architecture-Based Design of Multi-Agent Systems" by Danny Weyns ([https://doi.org/10.1007/978-3-642-01064-4)](https://doi.org/10.1007/978-3-642-01064-4)). Some of the architectural patterns for situated MAS defined there could provide a starting point for the discussion.
+
+AC: We need to revisit the definitions in the next meeting. also need to discuss the selection criteria for interaction mechanisms.
+
+JL: Presents his progress on the Agentic AI section. Raises several points to be discussed in the next meeting: proposes an updated definition for tools; asks where to position LLM agents or language agents with respect to terms already defined, i.e., agent and augmented language model; open discussion about the criteria used to select relevant related work.


### PR DESCRIPTION
These are the meeting notes from the regular meeting of the WebAgents CG on 29.08.2025.